### PR TITLE
Fix statistics actor registration

### DIFF
--- a/packages/backend/src/actors/QuizActor.ts
+++ b/packages/backend/src/actors/QuizActor.ts
@@ -111,8 +111,8 @@ export class QuizActor extends SubscribableActor<Quiz, QuizActorMessage, ResultT
 					{ name: `Stats_${uid}`, parent: this.ref, strategy: "Restart" },
 					uid
 				);
-				this.logger.debug(`Stats actor ${stats.name} created`);
-				this.runActors.set(uid, stats);
+                                this.logger.debug(`Stats actor ${stats.name} created`);
+                                this.statisticsActors.set(uid, stats);
 			}
 		} catch (e) {
 			this.logger.error(JSON.stringify(e));


### PR DESCRIPTION
## Summary
- ensure quiz actor registers statistics actors correctly
- keep removing statistics actors when entities are removed

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685e781d72588321850fe7f1eb6036df