### PR TITLE
Fix quiz validation error handling

### DIFF
--- a/packages/backend/src/actors/QuizActor.ts
+++ b/packages/backend/src/actors/QuizActor.ts
@@ -309,13 +309,22 @@ export class QuizActor extends SubscribableActor<Quiz, QuizActorMessage, ResultT
 									combined.statistics = quiz.statistics;
 								}
 							}
-							const quizToUpdate = quizSchema.parse(combined);
-							if (quiz.state && quiz.state !== "STOPPED") {
-								delete quizToUpdate.archived;
-							}
-							await this.storeEntity(quizToUpdate);
-							this.sendUpdateToSubscribers(quizToUpdate);
-							return quizToUpdate;
+                                                        let quizToUpdate: Quiz;
+                                                        try {
+                                                                quizToUpdate = quizSchema.parse(combined);
+                                                        } catch (e) {
+                                                                if (e instanceof Error) {
+                                                                        this.logger.error(e.message);
+                                                                        return serializeError(new Error(e.message));
+                                                                }
+                                                                return serializeError(new Error("Unknown validation error"));
+                                                        }
+                                                        if (quiz.state && quiz.state !== "STOPPED") {
+                                                                delete quizToUpdate.archived;
+                                                        }
+                                                        await this.storeEntity(quizToUpdate);
+                                                        this.sendUpdateToSubscribers(quizToUpdate);
+                                                        return quizToUpdate;
 						})
 						.orElse(Promise.resolve(new Error("Quiz not found")));
 					return result;

--- a/packages/backend/test/quizActor.test.ts
+++ b/packages/backend/test/quizActor.test.ts
@@ -1,0 +1,21 @@
+import { ActorSystem } from "ts-actors";
+import { QuizActor } from "../src/actors/QuizActor";
+import { QuizActorMessages } from "@recapp/models";
+
+/**
+ * This test ensures that the QuizActor handles invalid update payloads
+ * without throwing an exception. The actor should return a serialized
+ * error instead of crashing.
+ */
+
+describe("QuizActor", () => {
+    test("update with invalid payload returns serialized error", async () => {
+        const system = await ActorSystem.create({ systemName: "test" });
+        const quizActor = await system.createActor(QuizActor, { name: "QuizActor" });
+        const result = await system.ask(
+            quizActor,
+            QuizActorMessages.Update({ uid: "quiz-1", title: 5 } as any)
+        );
+        expect(result).toHaveProperty("name");
+    });
+});


### PR DESCRIPTION
## Summary
- handle validation errors in `QuizActor.Update` gracefully
- add failing unit test for invalid quiz update
