### PR TITLE
Fix branch detection in deploy action

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -5,18 +5,16 @@ on:
     branches:
       - main
       - 'feature/**'
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to deploy"
-        required: true
-        default: main
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      BRANCH_NAME: ${{ github.event.inputs.branch || github.head_ref || github.ref_name }}
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.7.0


### PR DESCRIPTION
## Summary
- fix `deploy-test.yml` to deploy the branch that triggered the run
- add `pull_request` trigger
- remove branch input default and use `github.head_ref` or `github.ref_name`